### PR TITLE
Add ADS-B Flask skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# playground
+# ADS-B Tracker Playground
+
+This project provides a minimal Flask application that displays ADS-B data on a Leaflet map.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the server:
+
+```bash
+python app.py
+```
+
+The application will attempt to fetch live data from the OpenSky Network API. In environments without internet access, the request will fail and return an error message.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,25 @@
+from flask import Flask, jsonify, render_template
+import requests
+
+app = Flask(__name__)
+
+ADS_B_API_URL = "https://opensky-network.org/api/states/all"
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/api/adsb')
+def adsb_feed():
+    """Fetch ADS-B data from the OpenSky Network API.
+    In a restricted environment this will fail, so consider
+    replacing with a local data source."""
+    try:
+        resp = requests.get(ADS_B_API_URL, timeout=5)
+        resp.raise_for_status()
+        return jsonify(resp.json())
+    except Exception as exc:
+        return jsonify({'error': str(exc)})
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,23 @@
+const map = L.map('map').setView([0, 0], 2);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  maxZoom: 19,
+  attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+async function fetchData() {
+  const res = await fetch('/api/adsb');
+  const data = await res.json();
+  // expecting data.states from OpenSky API
+  if (data.states) {
+    data.states.forEach(state => {
+      const lat = state[6];
+      const lon = state[5];
+      if (lat && lon) {
+        L.marker([lat, lon]).addTo(map)
+          .bindPopup(state[1] || 'aircraft');
+      }
+    });
+  }
+}
+
+fetchData();

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>ADS-B Tracker</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+    <style>
+      #map { height: 600px; }
+    </style>
+</head>
+<body>
+    <h1>ADS-B Tracker</h1>
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="/static/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add instructions in README for running an ADS-B tracker demo
- create a Flask server with an endpoint to fetch ADS-B data
- add a basic Leaflet frontend to display aircraft on a map
- add dependencies

## Testing
- `python -m py_compile app.py`